### PR TITLE
Maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/Geometry/Shapefile/ReadDbf.hs
+++ b/Geometry/Shapefile/ReadDbf.hs
@@ -12,7 +12,7 @@ module Geometry.Shapefile.ReadDbf ( readDbfFile,
 
 import Control.Monad       ( replicateM )
 import Control.Monad.Loops ( whileM )
-import Data.Binary.Get
+import Data.Binary.Get hiding ( getInt8 )
 
 import qualified Data.ByteString.Lazy as BL
 

--- a/Geometry/Shapefile/Types.hs
+++ b/Geometry/Shapefile/Types.hs
@@ -171,8 +171,7 @@ data RecContents =
       recPolZZs           :: [Double],
       recPolZMRange       :: (Double, Double),
       recPolZMs           :: [Double] }
-  -- | RecMultiPatch
-    deriving (Eq, Show)
+  deriving (Eq, Show)
 
 data RecBBox =
   RecBBox {

--- a/Geometry/Shapefile/Types.hs
+++ b/Geometry/Shapefile/Types.hs
@@ -7,7 +7,10 @@ Description : Type definitions used by the library. Currently (24 Nov 2015)
 Author      : Sam van Herwaarden <samvherwaarden@gmail.com>
 -}
 
-module Geometry.Shapefile.Types where
+module Geometry.Shapefile.Types(
+  module Geometry.Shapefile.Types,
+  Point
+  ) where
 
 import qualified Data.ByteString as BS
 

--- a/readshp.cabal
+++ b/readshp.cabal
@@ -23,7 +23,7 @@ library
                        Geometry.Shapefile.ReadShp,
                        Geometry.Shapefile.Types
   other-modules:       Geometry.Shapefile.Internal
-  build-depends:       base >=4.8 && <4.9,
+  build-depends:       base >=4.8 && <4.12,
                        binary,
                        bytestring,
                        data-binary-ieee754,

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: lts-5.14
+resolver: lts-11.15


### PR DESCRIPTION
* Bump upper bound on `base` to allow building with newer GHCs (tested with 8.2.2 and 8.4)
* Hide import in ` Geometry/Shapefile/ReadDbf.hs` to make it compile
* Use latest stack resolver (lts-11.15) in stack.yaml
* Delete commented out code that caused problems with haddock generation
* Add .gitignore
* Export `Point` type synonym from `Geometry.Shapefile.Internal` (otherwise I can't work with the polygons)